### PR TITLE
#2 - added support for more csproj types by automatically falling bac…

### DIFF
--- a/alma.debugify.csproj
+++ b/alma.debugify.csproj
@@ -8,7 +8,7 @@
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>debugify</ToolCommandName>
     <PackageOutputPath>./nupkg</PackageOutputPath>
-    <Version>1.0.5.0</Version>
+    <Version>1.0.6.0</Version>
     <Authors>gentledepp</Authors>
     <Company />
     <Product />
@@ -19,7 +19,8 @@
     <RepositoryType>GIT</RepositoryType>
     <PackageTags>nuget debug</PackageTags>
     <PackageLicenseFile>LICENSE.txt</PackageLicenseFile>
-    <PackageReleaseNotes>- swapping project files so git status does not complain about "file changed though contents are the same"</PackageReleaseNotes>
+    <PackageReleaseNotes>- fallback to msbuild if additional targets are required that dotnet pack does not support
+- swapping project files so git status does not complain about "file changed though contents are the same"</PackageReleaseNotes>
 
   </PropertyGroup>
 


### PR DESCRIPTION
…k to msbuild if additional targets are required that are not available to dotnet pack

